### PR TITLE
Add missing XML namespace

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin 
-  xmlns="http://www.phonegap.com/ns/plugins/1.0" id="cordova-plugin-qrscanner" version="3.0.1">
+  xmlns="http://www.phonegap.com/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-qrscanner" version="3.0.1">
   <name>QRScanner</name>
   <engines>
     <engine name="cordova" version=">=3.4.0"/>


### PR DESCRIPTION
Tags prefixed by `android:` were not associated with any namespace, causing some parsers to bail. Adding the namespace as mentioned in the cordova docs.